### PR TITLE
Fix .env file loading

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/joho/godotenv"
 )
@@ -17,21 +20,26 @@ type Config struct {
 
 // Returns Config based on the GO_ENV environment variable.
 // By default, it returns the standard database config.
-// If GO_ENV is set to "test", it loads the test database config
+// If GO_ENV is set to "test", it loads the test database config.
+// Path of .env files is the project root.
 func LoadConfig() (*Config, error) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return nil, fmt.Errorf("unable to determine current file location")
+	}
+	projectRoot := filepath.Join(filepath.Dir(currentFile), "..", "..")
 	env := os.Getenv("GO_ENV")
-	var err error
-
+	var envFile string
 	if env == "test" {
-		err = godotenv.Load(".env.test")
+		envFile = filepath.Join(projectRoot, ".env.test")
 	} else {
-		err = godotenv.Load(".env")
+		envFile = filepath.Join(projectRoot, ".env")
 	}
 
+	err := godotenv.Load(envFile)
 	if err != nil {
 		return nil, err
 	}
-
 	cfg := &Config{
 		Host:     os.Getenv("DB_HOST"),
 		Port:     os.Getenv("DB_PORT"),


### PR DESCRIPTION
The previous implementation relied on the directory from where LoadConfig was called. This created an issue when running go tests because .env.test had to be in the same directory as the test file. Now, environment files are always loaded from the project root.